### PR TITLE
[HLS-3903] Add support for confluent_kafka until 2.1.1 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#1706](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1706))
 - `opentelemetry-instrumentation-pymemcache` Update instrumentation to support pymemcache >4
   ([#1764](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/1764))
+- `opentelemetry-instrumentation-confluent-kafka` Add support for higher versions of confluent_kafka
+  ([#15](https://github.com/helios/opentelemetry-python-contrib/pull/15))
 
 ### Added
 

--- a/instrumentation/README.md
+++ b/instrumentation/README.md
@@ -11,7 +11,7 @@
 | [opentelemetry-instrumentation-boto3sqs](./opentelemetry-instrumentation-boto3sqs) | boto3 ~= 1.0 | No
 | [opentelemetry-instrumentation-botocore](./opentelemetry-instrumentation-botocore) | botocore ~= 1.0 | No
 | [opentelemetry-instrumentation-celery](./opentelemetry-instrumentation-celery) | celery >= 4.0, < 6.0 | No
-| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, < 2.0.0 | No
+| [opentelemetry-instrumentation-confluent-kafka](./opentelemetry-instrumentation-confluent-kafka) | confluent-kafka >= 1.8.2, <= 2.1.1 | No
 | [opentelemetry-instrumentation-dbapi](./opentelemetry-instrumentation-dbapi) | dbapi | No
 | [opentelemetry-instrumentation-django](./opentelemetry-instrumentation-django) | django >= 1.10 | Yes
 | [opentelemetry-instrumentation-elasticsearch](./opentelemetry-instrumentation-elasticsearch) | elasticsearch >= 2.0 | No

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "confluent-kafka >= 1.8.2, < 2.1.1",
+  "confluent-kafka >= 1.8.2, <= 2.1.1",
 ]
 test = [
   "opentelemetry-instrumentation-confluent-kafka[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "confluent-kafka >= 1.8.2, < 2.0.0",
+  "confluent-kafka >= 1.8.2, < 2.1.1",
 ]
 test = [
   "opentelemetry-instrumentation-confluent-kafka[instruments]",

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("confluent-kafka >= 1.8.2, < 2.1.1",)
+_instruments = ("confluent-kafka >= 1.8.2, <= 2.1.1",)

--- a/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
+++ b/instrumentation/opentelemetry-instrumentation-confluent-kafka/src/opentelemetry/instrumentation/confluent_kafka/package.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 
-_instruments = ("confluent-kafka >= 1.8.2, < 2.0.0",)
+_instruments = ("confluent-kafka >= 1.8.2, < 2.1.1",)

--- a/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
+++ b/opentelemetry-instrumentation/src/opentelemetry/instrumentation/bootstrap_gen.py
@@ -53,7 +53,7 @@ libraries = {
         "instrumentation": "opentelemetry-instrumentation-celery==0.39b0.dev",
     },
     "confluent-kafka": {
-        "library": "confluent-kafka >= 1.8.2, < 2.0.0",
+        "library": "confluent-kafka >= 1.8.2, <= 2.1.1",
         "instrumentation": "opentelemetry-instrumentation-confluent-kafka==0.39b0.dev",
     },
     "django": {


### PR DESCRIPTION
# Description

Add support for confluent_kafka instrumentation until 2.1.1 version.

Fixes # (issue)

## Type of change

- [ ] Add support for higher versions

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] test-instrumentation-confluent-kafka

# Does This PR Require a Core Repo Change?

- [ ] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
